### PR TITLE
Change </br> to <br> in generated code

### DIFF
--- a/src/components/preview.jsx
+++ b/src/components/preview.jsx
@@ -34,7 +34,7 @@ class Preview extends React.Component {
                 if (item.support) {
                     return (
                         '| ' +
-                        '[<img src="' + item.img + '" alt="' + item.name + '" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>' +
+                        '[<img src="' + item.img + '" alt="' + item.name + '" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>' +
                         item.name + ' ');
                 }
 


### PR DESCRIPTION
A line break can either be `<br>` or `<br />` but not `</ br>`

Thanks making this tool!